### PR TITLE
Make modules public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-mod commitment;
-mod polynomial;
-mod setup;
+pub mod commitment;
+pub mod polynomial;
+pub mod setup;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Resolve the issue with seemingly unused code by making the library's modules public.