### PR TITLE
oblast: Avoid compilation error in scalar multiplication.

### DIFF
--- a/oblast/src/lib.rs
+++ b/oblast/src/lib.rs
@@ -276,7 +276,7 @@ macro_rules! define_curve_struct {
                     mult(
                         &mut rhs.point,
                         &rhs.point,
-                        &self.value,
+                        self.value.b.as_ptr(),
                         constants::MODULUS_BIT_SIZE,
                     );
                 }


### PR DESCRIPTION
I was playing around with oblast and hit this compilation error...

Seems like blst has changed the interface of `blst_p1_mult` and this
compilation error has spawned.

```
error[E0308]: mismatched types
   --> oblast/src/lib.rs:279:25
    |
279 |                         &self.value,
    |                         ^^^^^^^^^^^ expected `u8`, found struct `blst_scalar`
...
298 | define_curve_struct!(P1, p1, G1, 48);
    | ------------------------------------- in this macro invocation
    |
    = note: expected raw pointer `*const u8`
                 found reference `&blst_scalar`
    = note: this error originates in the macro `define_curve_struct` (in Nightly bui
```

Dig into the internals of `blst_scalar` and get a raw pointer out of it...