### PR TITLE
Update with blst interfaces

### DIFF
--- a/oblast/Cargo.toml
+++ b/oblast/Cargo.toml
@@ -8,5 +8,5 @@ description = "High-level wrapper for blst"
 [dependencies]
 hex = "0.4.2"
 paste = "1.0.4"
-blst = "0.3.2"
+blst = "0.3.10"
 num-bigint = "0.3.1"

--- a/oblast/src/lib.rs
+++ b/oblast/src/lib.rs
@@ -276,7 +276,7 @@ macro_rules! define_curve_struct {
                     mult(
                         &mut rhs.point,
                         &rhs.point,
-                        &self.value,
+                        (&self.value.b).as_ptr(),
                         constants::MODULUS_BIT_SIZE,
                     );
                 }


### PR DESCRIPTION
It can't work with the old blst version (0.3.2). Updated.
